### PR TITLE
Remove lang=scss on DragDropContextProvider.

### DIFF
--- a/src/DragDropContextProvider.vue
+++ b/src/DragDropContextProvider.vue
@@ -42,6 +42,6 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 
 </style>


### PR DESCRIPTION
It's an empty style tag, and setting it to scss forces my project to install and setup Sass.

Thanks for this library by the way!